### PR TITLE
1.0.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 composer.lock
 .phpunit.cache
 /var
+php.Dockerfile
+compose.yaml

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   ],
   "type": "symfony-bundle",
   "require": {
-    "php": ">=8.1.0",
+    "php": ">=8.1",
     "composer-runtime-api": "^2.1.0",
     "php-http/client-common": "^2.7",
     "php-http/client-implementation": "*",
@@ -21,11 +21,11 @@
     "phpdocumentor/reflection-docblock": "^5.3",
     "psr/http-client-implementation": "^1.0",
     "psr/http-factory": "^1.0",
-    "psr/http-message": "^1.0",
+    "psr/http-message": "^2.0",
     "symfony/event-dispatcher": "*",
-    "symfony/framework-bundle": "^6.3",
-    "symfony/mime": "^6.3",
-    "symfony/serializer": "^6.3"
+    "symfony/framework-bundle": "^6.2",
+    "symfony/mime": "^6.2",
+    "symfony/serializer": "^6.2"
   },
   "require-dev": {
     "doctrine/annotations": "^2.0",
@@ -44,9 +44,9 @@
     "psr/cache-implementation": "2.0|3.0",
     "roave/security-advisories": "dev-latest",
     "symfony/config": "^6.3",
-    "symfony/property-access": "^6.3",
-    "symfony/property-info": "^6.3",
-    "symfony/var-exporter": "^6.3",
+    "symfony/property-access": "^6.2",
+    "symfony/property-info": "^6.2",
+    "symfony/var-exporter": "^6.2",
     "symplify/easy-coding-standard": "^12.0"
   },
   "autoload": {

--- a/config/services.php
+++ b/config/services.php
@@ -2,6 +2,7 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use ApiClientBundle\Builder\RequestUriBuilder;
 use ApiClientBundle\HTTP\HttpClient;
 use ApiClientBundle\HTTP\HttpClientInterface;
 use Http\Client\Common\Plugin\ErrorPlugin;
@@ -20,6 +21,7 @@ return static function (ContainerConfigurator $container): void {
     $services->set(HttpClientInterface::class)
              ->class(HttpClient::class)
              ->arg('$serializer', service(SerializerInterface::class))
+             ->arg('$container', service('service_container'))
              ->arg('$plugins', tagged_iterator('api.http_client.plugin'))
              ->public()
     ;

--- a/src/ApiClientBundle.php
+++ b/src/ApiClientBundle.php
@@ -2,6 +2,7 @@
 
 namespace ApiClientBundle;
 
+use ApiClientBundle\DependencyInjection\CompilerPass\ServiceCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -9,6 +10,7 @@ class ApiClientBundle extends Bundle
 {
     public function build(ContainerBuilder $container): void
     {
+        $container->addCompilerPass(new ServiceCompilerPass());
         parent::build($container);
     }
 }

--- a/src/Builder/QueryBuilderInterface.php
+++ b/src/Builder/QueryBuilderInterface.php
@@ -3,11 +3,12 @@
 namespace ApiClientBundle\Builder;
 
 use ApiClientBundle\Client\QueryInterface;
+use ApiClientBundle\Client\ServiceInterface;
 
 /**
  * @internal
  */
 interface QueryBuilderInterface
 {
-    public static function build(QueryInterface $query): mixed;
+    public static function build(QueryInterface $query, ServiceInterface $service): mixed;
 }

--- a/src/Builder/RequestBodyBuilder.php
+++ b/src/Builder/RequestBodyBuilder.php
@@ -3,6 +3,7 @@
 namespace ApiClientBundle\Builder;
 
 use ApiClientBundle\Client\QueryInterface;
+use ApiClientBundle\Client\ServiceInterface;
 use Http\Discovery\Psr17FactoryDiscovery;
 use Http\Message\MultipartStream\MultipartStreamBuilder;
 use Psr\Http\Message\StreamInterface;
@@ -12,7 +13,7 @@ class RequestBodyBuilder implements QueryBuilderInterface
     /**
      * @return array{stream: StreamInterface, boundary: null|string}|null
      */
-    public static function build(QueryInterface $query): ?array
+    public static function build(QueryInterface $query, ServiceInterface $service): ?array
     {
         $stream = null;
         $streamFactory = Psr17FactoryDiscovery::findStreamFactory();

--- a/src/Builder/RequestUriBuilder.php
+++ b/src/Builder/RequestUriBuilder.php
@@ -3,18 +3,19 @@
 namespace ApiClientBundle\Builder;
 
 use ApiClientBundle\Client\QueryInterface;
+use ApiClientBundle\Client\ServiceInterface;
 use Http\Discovery\Psr17FactoryDiscovery;
 use Psr\Http\Message\UriInterface;
 
 class RequestUriBuilder implements QueryBuilderInterface
 {
-    public static function build(QueryInterface $query): UriInterface
+    public static function build(QueryInterface $query, ServiceInterface $service): UriInterface
     {
         return Psr17FactoryDiscovery::findUriFactory()
                                     ->createUri()
-                                    ->withHost($query->getService()->getHost())
-                                    ->withPort($query->getService()->getPort())
-                                    ->withScheme($query->getService()->getScheme())
+                                    ->withHost($service->getHost())
+                                    ->withPort($service->getPort())
+                                    ->withScheme($service->getScheme())
                                     ->withPath($query->getPath() ?? '/')
                                     ->withQuery(http_build_query($query->getQuery()))
         ;

--- a/src/Client/AbstractQuery.php
+++ b/src/Client/AbstractQuery.php
@@ -47,11 +47,6 @@ abstract class AbstractQuery implements QueryInterface
      */
     protected array $plugins = [];
 
-    /**
-     * @var array<string, ServiceInterface>
-     */
-    private array $storedServices = [];
-
     public function getPath(): ?string
     {
         return $this->path;
@@ -82,15 +77,9 @@ abstract class AbstractQuery implements QueryInterface
         return $this->headers;
     }
 
-    public function getService(): ServiceInterface
+    public function getService(): string
     {
-        if (array_key_exists($this->service, $this->storedServices)) {
-            return $this->storedServices[$this->service];
-        }
-
-        $this->storedServices[$this->service] = new $this->service();
-
-        return $this->storedServices[$this->service];
+        return $this->service;
     }
 
     /**

--- a/src/Client/QueryInterface.php
+++ b/src/Client/QueryInterface.php
@@ -39,7 +39,10 @@ interface QueryInterface
      */
     public function getHeaders(): array;
 
-    public function getService(): ServiceInterface;
+    /**
+     * @return class-string<ServiceInterface>
+     */
+    public function getService(): string;
 
     /**
      * @return class-string<ResponseInterface>

--- a/src/DependencyInjection/CompilerPass/ServiceCompilerPass.php
+++ b/src/DependencyInjection/CompilerPass/ServiceCompilerPass.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace ApiClientBundle\DependencyInjection\CompilerPass;
+
+use ApiClientBundle\Client\ServiceInterface;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class ServiceCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        foreach ($container->getDefinitions() as $id => $definition) {
+            if (null === $definition->getClass() || !class_exists($definition->getClass())) {
+                continue;
+            }
+
+            try {
+                $class = new \ReflectionClass($definition->getClass());
+                if (!$class->implementsInterface(ServiceInterface::class)) {
+                    continue;
+                }
+
+                $definition->setPublic(true);
+                $container->setDefinition($id, $definition);
+            } catch (\Throwable) {
+            }
+        }
+    }
+}


### PR DESCRIPTION
- make minimal php version 8.1
- make minimal symfony version 6.2
- add possibility to use ServiceInterface implementations as container service